### PR TITLE
Output falsy values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ export class DebugFormat {
             if(value instanceof Error) {
                 values.push(`${INDENT}${key}: ${this._formatError(value, options)}`);
             } else {
-                const valueString = value && JSON.stringify(value);
+                const valueString = value != null && JSON.stringify(value);
                 if(valueString) {
                     // Make sure value isn't too long.
                     const cols = ('terminalWidth' in this.options)

--- a/test/debugFormatTest.ts
+++ b/test/debugFormatTest.ts
@@ -55,6 +55,23 @@ describe('DebugFormat', function() {
         );
     });
 
+    it('should exclude extra fields with value undefined or null ', function() {
+        const result = doTransform({
+            level: 'info',
+            message: 'Hello world!',
+            zero: 0,
+            not_true: false,
+            exclude_this: undefined,
+            exclude_this_too: null,
+        });
+
+        expect(result).to.equal(
+            `${this.date()} test[${process.pid}] INFO:    Hello world!\n` +
+            '    zero: 0\n' +
+            '    not_true: false'
+        );
+    });
+
     it('should make errors pretty', function() {
         const result = doTransform({
             level: 'info',


### PR DESCRIPTION
No longer filter out falsy values like `0` and `false` on line 76.

`value != null` will only filter out `undefined` and `null`. 